### PR TITLE
Fixed autovoting from being false by default

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -11,7 +11,6 @@
 'use strict';
 
 var vote = 'grow'; // you can change 'grow' to 'abandon' or 'stay' or false
-vote = false;
 
 var percentNonWordCharactersAllowed = .25;
 var ratioUppercaseToLowercase = .25;


### PR DESCRIPTION
README still said that voting was "grow" by default. It seemed like you changed it to false by accident while testing it (?).
